### PR TITLE
Corrections to example query in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
+      - run: "echo 'latest release: ${{ steps.get_latest_release.outputs.data }}'"
 ```
 
 To access deep values of `outputs.data`, check out [`gr2m/get-json-paths-action`](https://github.com/gr2m/get-json-paths-action).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Minimal example
 
 ```yml
-Name: Log latest release
+name: Log latest release
 on:
   push:
     branches:


### PR DESCRIPTION
There are a few problems with the current example query:

1. The `Name` keyword at the top is case-sensitive and should be lowercase
1. ~~The secret name is invalid (see below)~~
1. The echo command at the end fails with this error:
```
Run echo latest release: {
  echo latest release: {
    "repository": {
      "releases": {
        "nodes": []
      }
    }
  }
  shell: /bin/bash -e {0}
latest release: {
/home/runner/work/_temp/cd250459-337d-4891-8aba-c3cefbcb2ad9.sh: line 2: repository:: command not found
##[error]Process completed with exit code 127.
```

This PR attempts to correct these flaws so that it may be pasted into a new action and run as-is.