### PR TITLE
set all variables explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,6 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT_FOR_SEMANTIC_RELEASE }}
-      - run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v1.x"
+      - run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v2.x"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,6 @@ jobs:
                 }
               }
             }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
       - run: "echo latest release: '${{ steps.get_latest_release.outputs.data }}'"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ jobs:
                 }
               }
             }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: "echo 'latest release: ${{ steps.get_latest_release.outputs.data }}'"
@@ -49,10 +51,8 @@ To see additional debug logs, create a secret with the name: `ACTIONS_STEP_DEBUG
 
 ## How it works
 
-`octokit/graphql-action` is using [`@octokit/graphql`](https://github.com/octokit/graphql.js/) internally with some additions
-
-1. Requests are authenticated using the `GITHUB_TOKEN` environment variable. It is required to prevent rate limiting, as all anonymous requsets from the same origin count against the same low rate.
-2. The `owner` and `repo` parameters are preset to the repository that the action is run in.
+`octokit/graphql-action` is using [`@octokit/graphql`](https://github.com/octokit/graphql.js/) internally with the addition
+that requests are automatically authenticated using the `GITHUB_TOKEN` environment variable. It is required to prevent rate limiting, as all anonymous requsets from the same origin count against the same low rate.
 
 The actions sets `data` output to the response data. Note that it is a string, you cannot access any keys of the response at this point. The action also sets `headers` (again, to a JSON string) and `status`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   logLatestRelease:
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/graphql-action@v1.x
+      - uses: octokit/graphql-action@v2.x
         id: get_latest_release
         with:
           query: |

--- a/index.js
+++ b/index.js
@@ -6,38 +6,10 @@ const { Octokit } = require("@octokit/action");
 main();
 
 async function main() {
-  if (!process.env.GITHUB_REPOSITORY) {
-    core.setFailed(
-      'GITHUB_REPOSITORY missing, must be set to "<repo owner>/<repo name>"'
-    );
-    return;
-  }
-
   try {
-    const eventPayload = require(process.env.GITHUB_EVENT_PATH);
-    const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-    const repositoryId = eventPayload.repository.node_id;
-
+    ``;
     const octokit = new Octokit();
     const { query, ...variables } = getAllInputs();
-
-    if (/\$repositoryId\b/.test(query)) {
-      variables.repositoryId = variables.repositoryId || repositoryId;
-    }
-    if (/\$owner\b/.test(query)) {
-      variables.owner = variables.owner || owner;
-    }
-    if (/\$repo\b/.test(query)) {
-      variables.repo = variables.repo || repo;
-    }
-
-    core.debug(
-      `Setting default parameters: ${inspect({
-        owner,
-        repo,
-        repositoryId
-      })}`
-    );
 
     core.info(query);
     for (const [name, value] of Object.entries(variables)) {


### PR DESCRIPTION
BREAKING CHANGE: `$owner`, `$repo`, and `$repositoryId` variables are no longer set automatically to prevent accidents such as semantic-release/semantic-release#1373