### PR TITLE
fix(release): publish all `dist/*.js` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@semantic-release/git",
         {
           "assets": [
-            "dist/index.js"
+            "dist/*.js"
           ],
           "message": "build(release): compiled action for ${nextRelease.version}\n\n[skip ci]"
         }


### PR DESCRIPTION
closes #128
