### PR TITLE
Bump @actions/core version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.10.0",
         "@octokit/action": "^5.0.0"
       },
       "devDependencies": {
         "@semantic-release/git": "^10.0.0",
-        "@zeit/ncc": "^0.22.3",
+        "@vercel/ncc": "^0.36.1",
         "js-yaml": "^4.0.0",
         "prettier": "^2.7.1",
         "semantic-release": "^20.0.0"
@@ -653,11 +653,10 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "author": "Gregor Martynus (https://twitter.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@octokit/action": "^4.0.0"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.0",
-    "@zeit/ncc": "^0.22.3",
+    "@vercel/ncc": "^0.36.1",
     "js-yaml": "^4.0.0",
     "prettier": "^2.7.1",
     "semantic-release": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -17,16 +17,25 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@octokit/action": "^4.0.0"
+    "@octokit/action": "^5.0.0"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.0",
     "@vercel/ncc": "^0.36.1",
     "js-yaml": "^4.0.0",
     "prettier": "^2.7.1",
-    "semantic-release": "^19.0.0"
+    "semantic-release": "^20.0.0"
   },
   "release": {
+    "branches": [
+      "+([0-9]).x",
+      "main",
+      "next",
+      {
+        "name": "beta",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Please consider bumping version of '@actions/core' dependency? Github [recommends](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) using `1.10.0` of `@actions/core`.

Resolves #201 

`Type: Maintenance`
