### PR TITLE
Fix typo in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,11 +162,11 @@ jobs:
       - env:
           JSON_DATA: ${{ steps.get_commits_with_variables_parameter.outputs.data }}
         run: >
-          echo "<<<<<<<<<<<<<<<< DEBUG DATA\n"
           echo "${JSON_DATA}"
 
           COMMITS_COUNT=$(echo ${JSON_DATA} | jq
           '.repository.pullRequest.commits[] | length')
 
           echo "${COMMITS_COUNT}"
+
           [[ ${COMMITS_COUNT} -eq 6 ]] && exit 0 || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
             query  pullRequest(
               $repo:String!
               $owner:String!) {
-              repository(name:$repo, owner:$owner) { 
+              repository(name:$repo, owner:$owner) {
                 pullRequests(last:1) {
                   nodes {
                     number
@@ -162,7 +162,11 @@ jobs:
       - env:
           JSON_DATA: ${{ steps.get_commits_with_variables_parameter.outputs.data }}
         run: >
+          echo "<<<<<<<<<<<<<<<< DEBUG DATA\n"
+          echo "${JSON_DATA}"
+
           COMMITS_COUNT=$(echo ${JSON_DATA} | jq
           '.repository.pullRequest.commits[] | length')
 
+          echo "${COMMITS_COUNT}"
           [[ ${COMMITS_COUNT} -eq 6 ]] && exit 0 || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,4 +164,5 @@ jobs:
         run: >
           COMMITS_COUNT=$(echo ${JSON_DATA} | jq
           '.repository.pullRequest.commits[] | length')
+          
           [[ ${COMMITS_COUNT} -eq 6 ]] && exit 0 || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,11 +162,7 @@ jobs:
       - env:
           JSON_DATA: ${{ steps.get_commits_of_pull_request_with_variables_parameter.outputs.data }}
         run: >
-          echo "${JSON_DATA}"
-
           COMMITS_COUNT=$(echo ${JSON_DATA} | jq
           '.repository.pullRequest.commits[] | length')
-
-          echo "${COMMITS_COUNT}"
 
           [[ ${COMMITS_COUNT} -eq 6 ]] && exit 0 || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,5 +164,5 @@ jobs:
         run: >
           COMMITS_COUNT=$(echo ${JSON_DATA} | jq
           '.repository.pullRequest.commits[] | length')
-          
+
           [[ ${COMMITS_COUNT} -eq 6 ]] && exit 0 || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
           variables: |
             pr_number: 1
       - env:
-          JSON_DATA: ${{ steps.get_commits_with_variables_parameter.outputs.data }}
+          JSON_DATA: ${{ steps.get_commits_of_pull_request_with_variables_parameter.outputs.data }}
         run: >
           echo "${JSON_DATA}"
 


### PR DESCRIPTION
@nickfloyd and I have spent some time pairing on #219 today! It turns out the cause was a typo in the Actions step name when retrieving (successful) stored GraphQL query results. 

I also posit that another issue was the missing newline before attempting to run `[[ ${COMMITS_COUNT} -eq 6 ]]`. Without the newline, Actions tries to parse the entire block as one single command. 