### PR TITLE
Update tests to use node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
While this change is not technically required as part of our efforts to [drop support for NodeJS v14, v16](https://github.com/orgs/octokit/discussions/44) - this does help to get all of our packages and tooling in sync with a consistent node version. 


<!-- Issues are required for both bug fixes and features. -->

Part of: https://github.com/octokit/octokit.js/issues/2486

---

## Behavior

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- We were using node v16 in our test workflow

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- We are now using v18

