### PR TITLE
 Pass node-fetch as options.request.fetch to the Octokit constructor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1803,18 +1803,16 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // pkg/dist-src/index.js
 var dist_src_exports = {};
 __export(dist_src_exports, {
-  Octokit: () => Octokit,
-  RestEndpointMethodTypes: () => import_plugin_rest_endpoint_methods2.RestEndpointMethodTypes
+  Octokit: () => Octokit
 });
 module.exports = __toCommonJS(dist_src_exports);
 var import_core = __nccwpck_require__(6762);
 var import_auth_action = __nccwpck_require__(20);
 var import_plugin_paginate_rest = __nccwpck_require__(4193);
 var import_plugin_rest_endpoint_methods = __nccwpck_require__(3044);
-var import_plugin_rest_endpoint_methods2 = __nccwpck_require__(3044);
 
 // pkg/dist-src/version.js
-var VERSION = "5.0.6";
+var VERSION = "6.0.4";
 
 // pkg/dist-src/index.js
 var import_https_proxy_agent = __nccwpck_require__(7219);
@@ -1885,7 +1883,7 @@ __export(dist_src_exports, {
   createActionAuth: () => createActionAuth
 });
 module.exports = __toCommonJS(dist_src_exports);
-var import_auth_token = __nccwpck_require__(334);
+var import_auth_token = __nccwpck_require__(6434);
 var createActionAuth = function createActionAuth2() {
   if (!process.env.GITHUB_ACTION) {
     throw new Error(
@@ -1909,6 +1907,91 @@ var createActionAuth = function createActionAuth2() {
   }
   const token = definitions.pop();
   return (0, import_auth_token.createTokenAuth)(token);
+};
+// Annotate the CommonJS export names for ESM import in node:
+0 && (0);
+
+
+/***/ }),
+
+/***/ 6434:
+/***/ ((module) => {
+
+"use strict";
+
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// pkg/dist-src/index.js
+var dist_src_exports = {};
+__export(dist_src_exports, {
+  createTokenAuth: () => createTokenAuth
+});
+module.exports = __toCommonJS(dist_src_exports);
+
+// pkg/dist-src/auth.js
+var REGEX_IS_INSTALLATION_LEGACY = /^v1\./;
+var REGEX_IS_INSTALLATION = /^ghs_/;
+var REGEX_IS_USER_TO_SERVER = /^ghu_/;
+async function auth(token) {
+  const isApp = token.split(/\./).length === 3;
+  const isInstallation = REGEX_IS_INSTALLATION_LEGACY.test(token) || REGEX_IS_INSTALLATION.test(token);
+  const isUserToServer = REGEX_IS_USER_TO_SERVER.test(token);
+  const tokenType = isApp ? "app" : isInstallation ? "installation" : isUserToServer ? "user-to-server" : "oauth";
+  return {
+    type: "token",
+    token,
+    tokenType
+  };
+}
+
+// pkg/dist-src/with-authorization-prefix.js
+function withAuthorizationPrefix(token) {
+  if (token.split(/\./).length === 3) {
+    return `bearer ${token}`;
+  }
+  return `token ${token}`;
+}
+
+// pkg/dist-src/hook.js
+async function hook(token, request, route, parameters) {
+  const endpoint = request.endpoint.merge(
+    route,
+    parameters
+  );
+  endpoint.headers.authorization = withAuthorizationPrefix(token);
+  return request(endpoint);
+}
+
+// pkg/dist-src/index.js
+var createTokenAuth = function createTokenAuth2(token) {
+  if (!token) {
+    throw new Error("[@octokit/auth-token] No token passed to createTokenAuth");
+  }
+  if (typeof token !== "string") {
+    throw new Error(
+      "[@octokit/auth-token] Token passed to createTokenAuth is not a string"
+    );
+  }
+  token = token.replace(/^(token|bearer) +/i, "");
+  return Object.assign(auth.bind(null, token), {
+    hook: hook.bind(null, token)
+  });
 };
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
@@ -2709,7 +2792,7 @@ __export(dist_src_exports, {
 module.exports = __toCommonJS(dist_src_exports);
 
 // pkg/dist-src/version.js
-var VERSION = "6.1.2";
+var VERSION = "7.1.2";
 
 // pkg/dist-src/normalize-paginated-list-response.js
 function normalizePaginatedListResponse(response) {
@@ -2876,6 +2959,7 @@ var paginatingEndpoints = [
   "GET /orgs/{org}/projects",
   "GET /orgs/{org}/public_members",
   "GET /orgs/{org}/repos",
+  "GET /orgs/{org}/rulesets",
   "GET /orgs/{org}/secret-scanning/alerts",
   "GET /orgs/{org}/teams",
   "GET /orgs/{org}/teams/{team_slug}/discussions",
@@ -2965,6 +3049,8 @@ var paginatingEndpoints = [
   "GET /repos/{owner}/{repo}/releases",
   "GET /repos/{owner}/{repo}/releases/{release_id}/assets",
   "GET /repos/{owner}/{repo}/releases/{release_id}/reactions",
+  "GET /repos/{owner}/{repo}/rules/branches/{branch}",
+  "GET /repos/{owner}/{repo}/rulesets",
   "GET /repos/{owner}/{repo}/secret-scanning/alerts",
   "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations",
   "GET /repos/{owner}/{repo}/security-advisories",
@@ -3096,7 +3182,7 @@ __export(dist_src_exports, {
 module.exports = __toCommonJS(dist_src_exports);
 
 // pkg/dist-src/version.js
-var VERSION = "7.2.3";
+var VERSION = "8.0.0";
 
 // pkg/dist-src/generated/endpoints.js
 var Endpoints = {
@@ -16560,13 +16646,16 @@ const { inspect } = __nccwpck_require__(3837);
 const yaml = __nccwpck_require__(1917);
 const core = __nccwpck_require__(2186);
 const { Octokit } = __nccwpck_require__(1231);
+const fetch = __nccwpck_require__(467);
 
 main();
 
 async function main() {
   try {
     ``;
-    const octokit = new Octokit();
+    const octokit = new Octokit({
+      request: { fetch },
+    });
     const { query, ...variables } = getAllInputs();
 
     core.info(query);

--- a/index.js
+++ b/index.js
@@ -2,13 +2,16 @@ const { inspect } = require("util");
 const yaml = require("js-yaml");
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
+const fetch = require("node-fetch");
 
 main();
 
 async function main() {
   try {
     ``;
-    const octokit = new Octokit();
+    const octokit = new Octokit({
+      request: { fetch },
+    });
     const { query, ...variables } = getAllInputs();
 
     core.info(query);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",
-        "@octokit/action": "^5.0.0"
+        "@octokit/action": "^6.0.0"
       },
       "devDependencies": {
         "@semantic-release/git": "^10.0.0",
@@ -118,31 +118,55 @@
       }
     },
     "node_modules/@octokit/action": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-5.0.6.tgz",
-      "integrity": "sha512-jVZctvHzD9Cp1YZ5izcmcu2L9Y08Pe3ldjDu7vC2hyWQwz0fBhGrfKT5s4eNZ19K92UzO40cFzAFf1U4IOf13A==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.0.4.tgz",
+      "integrity": "sha512-lRvfUSjlCQWGi2DKSGYxPiu3xxWRrIOJ3i7kKTi+RWW2ejUr9hl/un/amira/Td+WrRAlvlcb7rSCY4hsnRTow==",
       "dependencies": {
-        "@octokit/auth-action": "^2.0.0",
+        "@octokit/auth-action": "^3.0.0",
         "@octokit/core": "^4.0.0",
-        "@octokit/plugin-paginate-rest": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^7.0.0",
-        "@octokit/types": "^9.0.0",
+        "@octokit/plugin-paginate-rest": "^7.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^8.0.0",
+        "@octokit/types": "^10.0.0",
         "https-proxy-agent": "^7.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
-    "node_modules/@octokit/auth-action": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.1.1.tgz",
-      "integrity": "sha512-396owpMa68wKT9tVf1rInQ0I8WdSJUXbEPWTDyIwqVGEd0xemKJwGHPv768Dh24BSJHY96MsUXJZ8CRaz28XCw==",
+    "node_modules/@octokit/action/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
       "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/types": "^9.0.0"
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-action": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-3.0.2.tgz",
+      "integrity": "sha512-QkRAlAFqELFdzddFjDA68IN26pJ2hoTLY2vNYsmX5vwcYIWiiQA1KDFIrqpdzZo4dpPJXM9E0drXyBpZhicGTA==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/types": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -202,29 +226,29 @@
       "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
+      "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
       "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
+        "@octokit/tsconfig": "^2.0.0",
+        "@octokit/types": "^9.3.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=4"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-8.0.0.tgz",
+      "integrity": "sha512-GtA8B7zkdxJv2OBVUtUeynu/OkWo272w2IpWC+QCQiUhgrRZ9Zrz2NgAiqYkVhlITGD3PcWYEjy9JR1HrzYtQA==",
       "dependencies": {
         "@octokit/types": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
@@ -324,9 +348,9 @@
       }
     },
     "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
     },
     "node_modules/@octokit/types": {
       "version": "9.3.2",
@@ -458,28 +482,6 @@
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
       }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
-      "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/tsconfig": "^2.0.0",
-        "@octokit/types": "^9.3.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/tsconfig": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
-      "dev": true
     },
     "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",
-        "@octokit/action": "^6.0.0"
+        "@octokit/action": "^6.0.5"
       },
       "devDependencies": {
         "@semantic-release/git": "^10.0.0",
@@ -118,36 +118,143 @@
       }
     },
     "node_modules/@octokit/action": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.0.4.tgz",
-      "integrity": "sha512-lRvfUSjlCQWGi2DKSGYxPiu3xxWRrIOJ3i7kKTi+RWW2ejUr9hl/un/amira/Td+WrRAlvlcb7rSCY4hsnRTow==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.0.5.tgz",
+      "integrity": "sha512-jcCZb+jR4nzHgj86wlUvbTv92hiZ4OWpI9dIoWRilbtT4HuVVNFZvQih8X/YE2GMVrLCVbBD0xkjeq+1m8Rcpw==",
       "dependencies": {
-        "@octokit/auth-action": "^3.0.0",
-        "@octokit/core": "^4.0.0",
-        "@octokit/plugin-paginate-rest": "^7.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^8.0.0",
-        "@octokit/types": "^10.0.0",
-        "https-proxy-agent": "^7.0.0"
+        "@octokit/auth-action": "^4.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^8.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^9.0.0",
+        "@octokit/types": "^11.0.0",
+        "undici": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/endpoint": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+      "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/graphql": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+      "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+      "dependencies": {
+        "@octokit/request": "^8.0.1",
+        "@octokit/types": "^11.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+      "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
+      "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/request": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+      "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.1.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/@octokit/request-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+      "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/action/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/auth-action": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-3.0.2.tgz",
-      "integrity": "sha512-QkRAlAFqELFdzddFjDA68IN26pJ2hoTLY2vNYsmX5vwcYIWiiQA1KDFIrqpdzZo4dpPJXM9E0drXyBpZhicGTA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-4.0.0.tgz",
+      "integrity": "sha512-sMm9lWZdiX6e89YFaLrgE9EFs94k58BwIkvjOtozNWUqyTmsrnWFr/M5LolaRzZ7Kmb5FbhF9hi7FEeE274SoQ==",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
-        "@octokit/types": "^10.0.0"
+        "@octokit/types": "^11.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -162,9 +269,9 @@
       }
     },
     "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -173,6 +280,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
       "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -181,6 +289,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -198,6 +307,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
       "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
@@ -211,6 +321,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
       "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dev": true,
       "dependencies": {
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
@@ -229,6 +340,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
       "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
+      "dev": true,
       "dependencies": {
         "@octokit/tsconfig": "^2.0.0",
         "@octokit/types": "^9.3.2"
@@ -238,28 +350,6 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-8.0.0.tgz",
-      "integrity": "sha512-GtA8B7zkdxJv2OBVUtUeynu/OkWo272w2IpWC+QCQiUhgrRZ9Zrz2NgAiqYkVhlITGD3PcWYEjy9JR1HrzYtQA==",
-      "dependencies": {
-        "@octokit/types": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/plugin-retry": {
@@ -322,6 +412,7 @@
       "version": "6.2.8",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
       "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -338,6 +429,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
       "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
@@ -350,12 +442,14 @@
     "node_modules/@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "dev": true
     },
     "node_modules/@octokit/types": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
       "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -891,6 +985,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
       "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -1013,6 +1108,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/callsites": {
@@ -1301,6 +1407,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1951,6 +2058,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
       "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -2595,7 +2703,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -2622,6 +2731,7 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6957,6 +7067,14 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7210,7 +7328,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/traverse": {
       "version": "0.6.7",
@@ -7261,6 +7380,17 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/unique-string": {
@@ -7328,12 +7458,14 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "@octokit/action": "^5.0.0"
+    "@octokit/action": "^6.0.0"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "@octokit/action": "^6.0.0"
+    "@octokit/action": "^6.0.5"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.0",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

After speaking with @gr2m we decided to pass in node-fetch (as an option) to the Octokit constructor now that [request.js has changed](https://github.com/octokit/request.js/pull/599).

This should ensure that the action will work as is without requiring a node bump and or changes on the consumer side (avoiding breaking changes)

Relates to https://github.com/octokit/graphql-action/pull/221

---

## Behavior

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->
- Prior to this change a breaking change was going to be introduced as part of this [effort](https://github.com/octokit/octokit.js/issues/2486) because of the change around support for Node's HTTP agent. 

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- There should no longer be a need for a breaking change to be introduced here and theoretically, this should still be able to "support" node v16.  The end goal would be to remove this once Actions moves to Node v18 as their runtime.
